### PR TITLE
Allow to easily exit image_test.py

### DIFF
--- a/image_test.py
+++ b/image_test.py
@@ -23,5 +23,8 @@ if __name__ == "__main__":
 
     cv2.imshow("output", img)
     # img2 = pydarknet.load_image(img)
-
-    cv2.waitKey(0)
+    
+     # Allow to easily exit the process with Ctrl+C 
+    while True:
+        cv2.waitKey(50)
+        


### PR DESCRIPTION
Currently, it hangs at the end, and Ctrl+C does nothing. This change allows exiting the process easily with Ctrl+C